### PR TITLE
[DOC][TYPO] Renamed AWS_ACCESS_SECRET_KEY to AWS_SECRET_ACCESS_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The technical test to apply for a *DevOps Engineer* role at *Foxintelligence* ht
 | Variable                              | Description             | Default                            |
 | ------------------------------------ | ---------------        | --------------------------------- |
 | AWS_ACCESS_KEY_ID                     | Ask recruiter for AWS credentials (IAM role or .aws/credentials file can be used also) | |
-| AWS_ACCESS_SECRET_KEY | Ask recruiter for AWS credentials (IAM role or .aws/credentials file can be used also) | |
+| AWS_SECRET_ACCESS_KEY | Ask recruiter for AWS credentials (IAM role or .aws/credentials file can be used also) | |
 | AWS_REGION | AWS region | eu-central-1 |
 | S3_BUCKET | S3 bucket | devops-test-foxintelligence |
 | MONGO_URI | MongoDB URI | mongodb://localhost:27017 |


### PR DESCRIPTION
"AWS_ACCESS_SECRET_KEY" was not understood automatically. Backend couldn't connect to your S3 bucket